### PR TITLE
support policykit processname under ubuntu 17.04

### DIFF
--- a/xapp/os.py
+++ b/xapp/os.py
@@ -62,8 +62,10 @@ def is_polkit_running():
     if is_desktop_kde() and is_process_running("polkit-kde-authentication-agent-1"):
         return True
     if is_desktop_mate() and is_process_running("polkit-mate-authentication-agent-1"):
-    	return True
+        return True
     elif is_process_running("polkit-gnome-authentication-agent-1"):
+        return True
+    elif is_process_running("polkitd"):
         return True
     else:
         return False


### PR DESCRIPTION
ok,

  under ubuntu 17.04 the policykit process name is "polkitd" - so I've added this as part of the "is policykit running" check.

Note - this is part of a separate change request on repo lightdm-settings so that pkexec is used correctly rather than the deprecated gksu implementation that is likely to disappear from the repos.