### PR TITLE
Use access() to test readability of /proc/cmdline

### DIFF
--- a/xapp/os.py
+++ b/xapp/os.py
@@ -43,7 +43,7 @@ def is_desktop_gnome():
 
 def is_live_session():
     is_live_session = False
-    if os.path.exists("/proc/cmdline"):
+    if os.access("/proc/cmdline", os.R_OK):
         cmdline = subprocess.check_output("cat /proc/cmdline", shell = True).decode("utf-8")
         for keyword in ["boot=casper", "boot=live"]:
             if keyword in cmdline:


### PR DESCRIPTION
Security focused distributions might limit the access to /proc/cmdline, making a simple existence tests insufficient, leading to failures like below:

```
org.cinnamon.ScreenSaver[5058]: cat: /proc/cmdline: Permission denied org.cinnamon.ScreenSaver[3308]: Traceback (most recent call last):
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/service.py", line 105, in handle_set_active
org.cinnamon.ScreenSaver[3308]:     self.manager.set_active(active)
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/manager.py", line 123, in set_active
org.cinnamon.ScreenSaver[3308]:     self.stage.activate(self.on_spawn_stage_complete)
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/stage.py", line 237, in activate
org.cinnamon.ScreenSaver[3308]:     callback()
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/manager.py", line 340, in on_spawn_stage_complete
org.cinnamon.ScreenSaver[3308]:     self.start_timers()
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/manager.py", line 409, in start_timers
org.cinnamon.ScreenSaver[3308]:     self.start_lock_delay()
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/manager.py", line 445, in start_lock_delay
org.cinnamon.ScreenSaver[3308]:     if not utils.user_can_lock():
org.cinnamon.ScreenSaver[3308]:   File "/usr/share/cinnamon-screensaver/util/utils.py", line 73, in user_can_lock
org.cinnamon.ScreenSaver[3308]:     if xapp.os.is_live_session() or xapp.os.is_guest_session():
org.cinnamon.ScreenSaver[3308]:   File "/usr/lib/python3/dist-packages/xapp/os.py", line 47, in is_live_session
org.cinnamon.ScreenSaver[3308]:     cmdline = subprocess.check_output("cat /proc/cmdline", shell = True).decode("utf-8")
org.cinnamon.ScreenSaver[3308]:   File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
org.cinnamon.ScreenSaver[3308]:     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
org.cinnamon.ScreenSaver[3308]:   File "/usr/lib/python3.10/subprocess.py", line 526, in run
org.cinnamon.ScreenSaver[3308]:     raise CalledProcessError(retcode, process.args,
org.cinnamon.ScreenSaver[3308]: subprocess.CalledProcessError: Command 'cat /proc/cmdline' returned non-zero exit status 1.
```

Use access(…, R_OK) instead to ensure the file is readable.

Signed-off-by: Mathias Krause <minipli@grsecurity.net>