### PR TITLE
fix lintian error and build failure (closes #21)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends:
  debhelper-compat (= 12),
  meson (>= 0.47.0),
  dh-python,
+ gobject-introspection,
  python3-all
 Standards-Version: 3.9.5
 X-Python-Version: >= 2.6

--- a/debian/rules
+++ b/debian/rules
@@ -1,2 +1,7 @@
+#!/usr/bin/make -f
+# See debhelper(7) (uncomment to enable)
+# output every command that modifies files on the build system.
+# export DH_VERBOSE = 1
+
 %:
-	dh $@ --with=python3,gir
+	dh ${@} --with=python3,gir


### PR DESCRIPTION
- fix build error due to missing build
  dependency: gobject-introspection
- fix lintian error: debian-rules-not-a-makefile