### PR TITLE
Make python installation configurable for distro packaging.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('python-xapp', version: '2.4.1', meson_version: '>=0.47.0')
 
 pymod = import('python')
-python3 = pymod.find_installation('python3')
+python3 = pymod.find_installation(get_option('python_target'))
 
 subdir('xapp')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('python_target', type: 'string', value: 'python3', description: 'Python installation to target')


### PR DESCRIPTION
Add a configuration option for selecting the target python installation.

This is used by Gentoo to install python3-xapp into multiple python installations by executing the build for each individual installation.